### PR TITLE
#4 maven/tycho 1.0.0 pomless build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /classes
 /.class
 /.build
+
+# maven stuff
+target
+.polyglot.build.properties

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>org.eclipse.tycho.extras</groupId>
+    <artifactId>tycho-pomless</artifactId>
+    <version>1.0.0</version>
+  </extension>
+</extensions>

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ http://nextinterfaces.com/http4e/install
 
 Build Instructions
 --------------
+
+## With Ant
+
 ```
 project-root> ant
 ```
@@ -40,6 +43,21 @@ install/
   plugins/
   http4e-eclipse-rest-http-client.tar
 ```
+
+## With Maven
+
+```
+project-root> mvn build
+```
+
+And look into `http4e-Site/target`
+
+To update version
+```bash
+mvn org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=5.0.13-SNAPSHOT
+```
+
+
 
 License
 --------------

--- a/http4e-Feature/feature.xml
+++ b/http4e-Feature/feature.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
-      id="org.roussev.http4e.ui"
+      id="org.roussev.http4e.feature"
       label="Eclipse HTTP Client (HTTP4e)"
       version="5.0.12"
       provider-name="nextinterfaces.com">
 
    <description url="http://www.nextinterfaces.com/http4e/">
-	   HTTP4e is an Eclipse plugin that helps you quickly build HTTP packets enabling you to efficiently test and create Rest Service and Web Service calls.
+      HTTP4e is an Eclipse plugin that helps you quickly build HTTP packets enabling you to efficiently test and create Rest Service and Web Service calls.
 Eclipse HttpClient (HTTP4e) features:
-	- Making an HTTP call directly from Eclipse IDE
-	- Visual Editor Panels for headers, parameters and http packet body
-	- Tabbed browsing (allowing replaying different RESTful, HTTP calls on separate tabs)
-	- History support (persisting your valuable REST calls)
-	- One-click  RESTful, HTTP Java code generation
-	- Code assist
-	- Syntax coloring
-	- Different views: "Raw", "Pretty", "Hex", "Browser" and "JSON" view
-	- Double click re-size aware
-	- Available on Windows, MacOS X, Linux, Solaris
-	- Build on top of Apache HttpClient
-	- Proxy Configuration Preferences
-	- SSL HTTPS support
-	- Build on top of industrial proven Apache HttpClient
-	- HTTP tampering
-	- Great usability and great UI
+ - Making an HTTP call directly from Eclipse IDE
+ - Visual Editor Panels for headers, parameters and http packet body
+ - Tabbed browsing (allowing replaying different RESTful, HTTP calls on separate tabs)
+ - History support (persisting your valuable REST calls)
+ - One-click  RESTful, HTTP Java code generation
+ - Code assist
+ - Syntax coloring
+ - Different views: &quot;Raw&quot;, &quot;Pretty&quot;, &quot;Hex&quot;, &quot;Browser&quot; and &quot;JSON&quot; view
+ - Double click re-size aware
+ - Available on Windows, MacOS X, Linux, Solaris
+ - Build on top of Apache HttpClient
+ - Proxy Configuration Preferences
+ - SSL HTTPS support
+ - Build on top of industrial proven Apache HttpClient
+ - HTTP tampering
+ - Great usability and great UI
 Requirements:
 Java 5+
 Eclipse 3.2+
@@ -34,22 +34,22 @@ Eclipse 3.2+
    </copyright>
 
    <license url="http://nextinterfaces.com/http4e/license/">
-LICENSE AGREEMENT
+      LICENSE AGREEMENT
 
 Apache License, Version 2.0
 
 Copyright 2017 NEXTinterfaces.com
 
-The Eclipse HttpClient (HTTP4e) software is licensed under the Apache License, v. 2.0 (the "License"); 
+The Eclipse HttpClient (HTTP4e) software is licensed under the Apache License, v. 2.0 (the &quot;License&quot;); 
 you may not use this file except in compliance with the License. You may obtain a 
 copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed 
-under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR 
 CONDITIONS OF ANY KIND, either express or implied. See the License for the 
-specific language governing permissions and limitations under the License. 
+specific language governing permissions and limitations under the License.
    </license>
 
    <url>

--- a/http4e-Site/category.xml
+++ b/http4e-Site/category.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <feature url="features/org.roussev.http4e.feature_5.0.12.jar" id="org.roussev.http4e.feature" version="5.0.12">
+      <category name="tools"/>
+   </feature>
+   <category-def name="tools" label="Tools"/>
+</site>

--- a/http4e-Site/pom.xml
+++ b/http4e-Site/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<artifactId>http4e</artifactId>
+		<groupId>org.nodeclipse</groupId>
+		<version>5.0.12-SNAPSHOT</version>
+	</parent>
+	<artifactId>http4e.site</artifactId>
+	<packaging>eclipse-repository</packaging>
+	<name>http4e :: update site</name>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.nodeclipse</groupId>
+  <artifactId>http4e</artifactId>
+  <version>5.0.12-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>http4e :: parent</name>
+  <description>http4e parent</description>
+
+  <prerequisites>
+    <maven>3.0</maven>
+  </prerequisites>
+
+  <properties>
+    <java.version>1.6</java.version>
+  	<maven.version>3.0</maven.version>
+  	<tycho.version>1.0.0</tycho.version>
+  	<tycho.test.jvmArgs>-Xmx512m -XX:MaxPermSize=256m</tycho.test.jvmArgs>
+  	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>luna</id>
+      <layout>p2</layout>
+      <url>http://download.eclipse.org/releases/luna</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>sonatype-public</id>
+      <url>http://repository.sonatype.org/content/groups/sonatype-public-grid</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+		<artifactId>tycho-maven-plugin</artifactId>
+        <version>${tycho.version}</version>
+        <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <version>${tycho.version}</version>
+        <configuration>
+          <resolver>p2</resolver>
+          <pomDependencies>consider</pomDependencies>
+          <ignoreTychoRepositories>true</ignoreTychoRepositories>
+        </configuration>
+      </plugin>
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-packaging-plugin</artifactId>
+          <version>${tycho.version}</version>
+          <configuration>
+            <format>yyyyMMdd-HHmm</format>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-surefire-plugin</artifactId>
+          <version>${tycho.version}</version>
+          <configuration>
+            <useUIHarness>true</useUIHarness>
+            <includes>
+              <include>**/*Test.java</include>
+            </includes>
+            <argLine>${tycho.test.jvmArgs}</argLine>
+            <!-- kill test JVM if tests take more than 1 minute (60 seconds) to finish -->
+            <forkedProcessTimeoutInSeconds>60</forkedProcessTimeoutInSeconds>
+          </configuration>
+        </plugin>
+        <plugin>
+        	<groupId>org.apache.maven.plugins</groupId>
+        	<artifactId>maven-assembly-plugin</artifactId>
+        	<version>2.3</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>  
+  <modules>
+    <module>http4e-Core</module>
+    <module>http4e-Plugin</module>
+    <module>http4e-Feature</module>
+    <module>http4e-Site</module>
+  </modules>
+</project>


### PR DESCRIPTION
2nd build with maven/tycho 1.0.0 pomless build.

Note that feature id was the same as plugin id, so it was changed.



This is not clean PR, because of whitespaces changes.
See https://github.com/nextinterfaces/http4e/compare/master...Nodeclipse:master?w=1 without 
whitespaces

I still cannot figure out why EGit does so.